### PR TITLE
1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "bulton-fr/bfw-controller": "~2.0",
 		"nikic/fast-route": "v0.7.0"
 	},
-	"minimum-stability": "stable",
 	"autoload":
 	{
 		"psr-4":

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "bulton-fr/bfw-controller": "~2.0",
 		"nikic/fast-route": "v0.7.0"
 	},
+	"minimum-stability": "dev",
 	"autoload":
 	{
 		"psr-4":


### PR DESCRIPTION
Update du composer.json

La version 2.0 de bfw-controller est encore marqué en dev. D'où la mise à jour du minimum-stability.
